### PR TITLE
chore: simplify use of context

### DIFF
--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -50,61 +50,56 @@ func NewJobTracker(store Store, stopInterval time.Duration) (*Tracker, error) {
 }
 
 // Run runs a new job and returns the job ID.
-func (j *Tracker) Run(jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
-	parentCtx := context.Background()
-	jobId, err := j.store.AddJob(parentCtx, jobType)
+func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
+	jobId, err := j.store.AddJob(ctx, jobType)
 	if err != nil {
 		return jobId, err
 	}
 
-	go j.handleJob(parentCtx, jobId, maxDuration, job)
+	// no context is passed to handleJob as this is a background
+	// job and is not tied to the request context.
+	go j.handleJob(jobId, maxDuration, job)
 
 	return jobId, nil
 }
 
-// handleJob runs a job with a given context, job ID, and deadline.
+// handleJob runs a job with a given job ID, and deadline.
 // It manages the job's lifecycle, including setting its status in the store, handling retries on store operations,
-// and responding to stop signals or context cancellations. The job is run in a separate goroutine, and its status
-// is updated as running, successful, or failed based on its result or context expiration.
-// If a stop signal is received or the context is canceled or times out, the job is marked as failed.
-// Store operations are retried up to 5 times with a 30-second delay between attempts in case of transient errors.
+// and responding to stop signals. The job is run in a separate goroutine, and its status is updated as running,
+// successful, or failed based on its result or context expiration.
+// If a stop signal is received or the job reaches its maximum duration, the job is marked as failed.
 func (j *Tracker) handleJob(
-	parentCtx context.Context,
 	id uuid.UUID,
 	maxDuration time.Duration,
 	job func(ctx context.Context) error,
 ) {
-	jobCtx, cancelJob := context.WithTimeout(parentCtx, maxDuration)
+	jobCtx, cancelJob := context.WithTimeout(context.Background(), maxDuration)
 	defer cancelJob()
 
 	jobErrCh := make(chan error)
 
-	go j.runJob(parentCtx, jobCtx, id, jobErrCh, job)
-	j.monitorJob(parentCtx, jobCtx, id, jobErrCh, cancelJob)
+	go j.runJob(jobCtx, id, jobErrCh, job)
+	j.monitorJob(id, jobErrCh, cancelJob)
 }
 
-func (j *Tracker) runJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
+func (j *Tracker) runJob(ctx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
+
 	if err := j.store.SetJobRunning(ctx, id); err != nil {
 		jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
 		return
 	}
-	jobErrCh <- job(jobCtx)
+	jobErrCh <- job(ctx)
 }
 
-func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, cancelJob context.CancelFunc) {
+func (j *Tracker) monitorJob(id uuid.UUID, jobErrCh chan error, cancelJob context.CancelFunc) {
 	ticker := time.NewTicker(j.stopInterval)
 	defer ticker.Stop()
 
+	ctx := context.Background()
+	stopped := false
 	// TODO(ale8k): Add monitoring for failed status settings.
 	for {
 		select {
-		case <-jobCtx.Done():
-			ctxErr := jobCtx.Err()
-			if err := j.store.SetJobFailed(ctx, id, ctxErr); err != nil {
-				zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
-			}
-
-			return
 		case err := <-jobErrCh:
 			if err != nil {
 				if err := j.store.SetJobFailed(ctx, id, err); err != nil {
@@ -119,6 +114,10 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 
 			return
 		case <-ticker.C:
+			if stopped {
+				// If we are already stopped, we don't need to check the stop signal again.
+				continue
+			}
 			shouldStop, err := j.store.GetJobStopSignal(ctx, id)
 
 			// If we fail to get the stop signal for any reason, we do a best
@@ -127,6 +126,7 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 			// do eventually write the correct status.
 			if err != nil || shouldStop {
 				cancelJob()
+				stopped = true
 			}
 		}
 	}


### PR DESCRIPTION
I've simplified the use of contexts in the job tracker. Instead of passing around multiple contexts and being careful about which one to use, we notice that the case statement `case <-jobCtx.Done():` is being used to check that the job has ended due to timeout or cancellation. But we also have the `jobErrCh` channel returning any errors from the job.

So we can simplify all by realising that it's the responsibility of the job to end early if the context completes. The job will then return the error from the job and all we need to do in the `monitorJob` function is receive the error which should be one related to the context.

Now we don't have to worry about which context to use.